### PR TITLE
build: add the FATHOM_TOKEN environment variable

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,6 +39,8 @@ jobs:
         run: npm run lint
 
       - name: Generate ⚙️
+        env:
+          FATHOM_TOKEN: JDHEHWUV
         run: npm run generate
 
       - name: Deploy 🚀


### PR DESCRIPTION
This adds the `FANTHOM_TOKEN` available during the build. Since I don't have access to the settings of this repository I hardcoded the value.
