### PR TITLE
build: remove continuous delivery in netlify

### DIFF
--- a/.github/workflows/build-and-deploy-workflow.yml
+++ b/.github/workflows/build-and-deploy-workflow.yml
@@ -72,53 +72,7 @@ jobs:
           name: cypress downloads
           path: cypress/downloads/
 
-  cd_staging:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
-    environment: staging
-    needs: ci
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        node: [15]
-
-    steps:
-      - name: Checkout 🛎
-        uses: actions/checkout@master
-
-      - name: Setup node env 🏗
-        uses: actions/setup-node@v2.1.2
-        with:
-          node-version: ${{ matrix.node }}
-          check-latest: true
-
-      - name: Cache node_modules 📦
-        uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-
-      - name: Install dependencies 👨🏻‍💻
-        run: npm ci
-
-      - name: Generate ⚙️
-        env:
-          BASE_PATH: ${{ secrets.BASE_PATH }}
-          FATHOM_TOKEN: ${{ secrets.FATHOM_TOKEN }}
-        run: npm run generate
-
-      - name: Deploy 🚀
-        uses: netlify/actions/cli@master
-        with:
-          args: deploy --dir=dist --functions=functions --prod
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-
-  cd_production:
+  cd:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment: production
     needs: ci


### PR DESCRIPTION
Since we want Netlify's preview apps we need to leave the CD pipeline to them. In this PR I am removing the CD step that we made for the `staging` environment since it is no longer needed.