### PR TITLE
fix: add pull request sha to the checkout action

### DIFF
--- a/.github/workflows/build-and-deploy-workflow.yml
+++ b/.github/workflows/build-and-deploy-workflow.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout 🛎
         uses: actions/checkout@master
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup node env 🏗
         uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
This fixes the 💡🏠 checks. They are now visible in the status checks below. 

_source: https://github.com/GoogleChrome/lighthouse-ci/issues/172#issuecomment-571928200_