### PR TITLE
fix: save the date a11y

### DIFF
--- a/components/common/CalendarDropdown.vue
+++ b/components/common/CalendarDropdown.vue
@@ -1,48 +1,50 @@
 <template>
   <div>
-    <CommonCustomButton
-      v-if="type == 'button' && !showDropdown"
-      icon="calendar"
-      icon-suffix
-      @click="toggleDropdown"
-    >
-      Save the Date
-    </CommonCustomButton>
-    <div
-      v-else
-      class="dropdown-wrapper"
-      :class="[
-        `dropdown-wrapper--${type}`,
-        {
-          'dropdown-wrapper--open': showDropdown,
-        },
-      ]"
-    >
-      <div class="dropdown" :class="showDropdown && 'dropdown--open'">
-        <button
-          class="dropdown__title"
-          :class="[
-            `dropdown__title--${type}`,
-            {
-              'dropdown__title--nav-open': showDropdown,
-            },
-          ]"
-          :aria-label="label"
-          aria-haspopup="true"
-          :aria-expanded="showDropdown"
-          role="listbox"
-          aria-controls="calendar-list"
-          @click="toggleDropdown"
-          @keyup.esc="showDropdown = false"
-        >
-          {{ title }}
-          <CloseIcon
-            class="dropdown__close"
-            :class="showDropdown && 'dropdown__close--visible'"
-            aria-hidden="true"
-          />
-        </button>
-        <focus-trap :active="showDropdown">
+    <focus-trap :active="showDropdown">
+      <CommonCustomButton
+        v-if="type == 'button' && !showDropdown"
+        icon="calendar"
+        icon-suffix
+        @click="toggleDropdown"
+        @keyup.esc="showDropdown = false"
+      >
+        Save the Date
+      </CommonCustomButton>
+      <div
+        v-else
+        class="dropdown-wrapper"
+        :class="[
+          `dropdown-wrapper--${type}`,
+          {
+            'dropdown-wrapper--open': showDropdown,
+          },
+        ]"
+      >
+        <div class="dropdown" :class="showDropdown && 'dropdown--open'">
+          <button
+            class="dropdown__title"
+            :class="[
+              `dropdown__title--${type}`,
+              {
+                'dropdown__title--nav-open': showDropdown,
+              },
+            ]"
+            :aria-label="label"
+            aria-haspopup="true"
+            :aria-expanded="showDropdown"
+            role="listbox"
+            aria-controls="calendar-list"
+            @click="toggleDropdown"
+            @keyup.esc="showDropdown = false"
+          >
+            {{ title }}
+            <CloseIcon
+              class="dropdown__close"
+              :class="showDropdown && 'dropdown__close--visible'"
+              aria-hidden="true"
+            />
+          </button>
+
           <ul
             id="calendar-list"
             class="dropdown__options"
@@ -74,9 +76,9 @@
               </a>
             </li>
           </ul>
-        </focus-trap>
+        </div>
       </div>
-    </div>
+    </focus-trap>
   </div>
 </template>
 

--- a/components/common/CalendarDropdown.vue
+++ b/components/common/CalendarDropdown.vue
@@ -6,7 +6,6 @@
         icon="calendar"
         icon-suffix
         @click="toggleDropdown"
-        @keyup.esc="showDropdown = false"
       >
         Save the Date
       </CommonCustomButton>


### PR DESCRIPTION
## ✍️ Description
With the changes introduced in [this PR](https://github.com/github/globalmaintainersummit.github.com/pull/67) the Save the date button wasn't very accessible by keyboard. This tiny change (moving the focus trap to the whole component) will improve it a bit.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.