### PR TITLE
fix(topbar): Fix scroll when navigation is open on mobile

### DIFF
--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -64,7 +64,7 @@ export default {
   },
   methods: {
     toggleNav() {
-      this.$emit('toggle', !this.active)
+      this.$emit('toggle')
     },
   },
 }

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -16,7 +16,7 @@
       <button
         class="nav__hamburguer"
         :aria-label="`${active ? 'Close' : 'Open'} navigation`"
-        @click="active = !active"
+        @click="toggleNav"
       >
         <Hamburguer :active="active" />
       </button>
@@ -56,10 +56,16 @@ export default {
     GitHub,
     FocusTrap,
   },
-  data() {
-    return {
-      active: false,
-    }
+  props: {
+    active: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  methods: {
+    toggleNav() {
+      this.$emit('toggle', !this.active)
+    },
   },
 }
 </script>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -16,8 +16,8 @@ export default {
     }
   },
   methods: {
-    toggleNav(value) {
-      this.navActive = value
+    toggleNav() {
+      this.navActive = !this.navActive
     },
   },
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <TopNav />
+  <div :class="{ 'open-nav': navActive }">
+    <TopNav :active="navActive" @toggle="toggleNav" />
     <main class="main">
       <Nuxt />
     </main>
@@ -8,6 +8,20 @@
     <Footer />
   </div>
 </template>
+<script>
+export default {
+  data() {
+    return {
+      navActive: false,
+    }
+  },
+  methods: {
+    toggleNav(value) {
+      this.navActive = value
+    },
+  },
+}
+</script>
 
 <style lang="scss" scoped>
 .main {
@@ -15,5 +29,11 @@
   z-index: var(--z-index-content);
   width: 100%;
   overflow: hidden;
+}
+.open-nav {
+  @media screen and (max-width: $screen-sm) {
+    height: 100vh;
+    overflow: hidden;
+  }
 }
 </style>


### PR DESCRIPTION
## ✍️ Description

- [x] Refactor default layout and `topbar` component to solve the vertical scrolling once the navigation is active in mobile viewports.

## ✅ QA

Before requesting a review, please make sure that:

- [x] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
