### PR TITLE
feat: add talk section to maintainer page (design)

### DIFF
--- a/components/maintainer/Talk.vue
+++ b/components/maintainer/Talk.vue
@@ -1,3 +1,52 @@
 <template>
-  <div>TODO</div>
+  <div class="talk">
+    <CommonWave class="talk__decoration" />
+    <div class="talk__details">
+      <p>text with <a href="/schedule">link</a></p>
+      <p class="talk__details--date">date</p>
+    </div>
+    <CommonCustomButton
+      icon="calendar"
+      icon-suffix
+      to="/schedule"
+      class="talk__cta"
+    >
+      Check Schedule
+    </CommonCustomButton>
+  </div>
 </template>
+
+<style lang="scss" scoped>
+.talk {
+  display: flex;
+  flex-direction: column;
+  margin-top: 80px;
+  margin-bottom: 16px;
+
+  &__decoration {
+    width: 100%;
+  }
+
+  &__details {
+    margin-top: 72px;
+    font-weight: var(--fw-bold);
+    font-family: var(--ff-title);
+    &--date {
+      color: var(--fc-accent);
+    }
+
+    p {
+      @include mobileToDesktopFontSize(var(--fs-default), var(--fs-medium));
+    }
+
+    a {
+      @include linksWithinText();
+    }
+  }
+
+  &__cta {
+    align-self: flex-end;
+    margin-top: 24px;
+  }
+}
+</style>

--- a/components/maintainer/Talk.vue
+++ b/components/maintainer/Talk.vue
@@ -2,7 +2,10 @@
   <div class="talk">
     <CommonWave class="talk__decoration" />
     <div class="talk__details">
-      <p>text with <a href="/schedule">link</a></p>
+      <p>
+        {{ speakerName }} will be talking about
+        <a href="/schedule">link</a> with
+      </p>
       <p class="talk__details--date">date</p>
     </div>
     <CommonCustomButton
@@ -15,6 +18,28 @@
     </CommonCustomButton>
   </div>
 </template>
+
+<script>
+export default {
+  props: {
+    handler: {
+      type: String,
+      required: true,
+    },
+    speakerName: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      topic: null,
+      coSpeakers: [],
+      date: null,
+    }
+  },
+}
+</script>
 
 <style lang="scss" scoped>
 .talk {

--- a/pages/maintainer/_profile.vue
+++ b/pages/maintainer/_profile.vue
@@ -20,7 +20,10 @@
         :profile="maintainer.profile"
       />
       <MaintainerProject :project="maintainer.project" />
-      <MaintainerTalk />
+      <!-- <MaintainerTalk
+        :handler="maintainer.handler"
+        :speaker-name="maintainer.profile.name"
+      /> -->
     </div>
   </section>
 </template>

--- a/pages/maintainer/_profile.vue
+++ b/pages/maintainer/_profile.vue
@@ -20,6 +20,7 @@
         :profile="maintainer.profile"
       />
       <MaintainerProject :project="maintainer.project" />
+      <!-- TODO uncomment once we have all the content to finish this section -->
       <!-- <MaintainerTalk
         :handler="maintainer.handler"
         :speaker-name="maintainer.profile.name"

--- a/pages/maintainer/_profile.vue
+++ b/pages/maintainer/_profile.vue
@@ -20,7 +20,7 @@
         :profile="maintainer.profile"
       />
       <MaintainerProject :project="maintainer.project" />
-      <!-- <MaintainerTalk /> -->
+      <MaintainerTalk />
     </div>
   </section>
 </template>


### PR DESCRIPTION
## ✍️ Description
Add styles for the talk section in the maintainer page. The component is commented as right now we don't have the content to build the text.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots
<img width="1069" alt="Screenshot 2021-05-11 at 17 09 38" src="https://user-images.githubusercontent.com/39853718/117839618-adb56580-b27b-11eb-94de-8184ed72ebe5.png">

## 🔗 Relevant URLs
- [Task](https://app.clickup.com/t/jn5vz5)