### PR TITLE
fix: make wavy underline for links thinner

### DIFF
--- a/assets/scss/mixins/main.scss
+++ b/assets/scss/mixins/main.scss
@@ -42,8 +42,11 @@
 
 /*
  * Define common styles for all the waves in the page
+ $bottom: define how far the wavy line will be from the element bottom
+ $height: define how thick the line will be
+ $bg-size-height: define how thick the line will be
  */
-@mixin wave($bottom) {
+@mixin wave($bottom, $height: 24px, $bg-size-height: 20px) {
   position: relative;
 
   &::after {
@@ -51,7 +54,7 @@
     bottom: $bottom;
     left: 0;
     width: 100%;
-    height: 24px;
+    height: $height;
     background: radial-gradient(
           52% 100% at 50% -12px,
           transparent calc(100% - 5px),
@@ -66,7 +69,7 @@
         )
         0 calc(100% - 15px);
     background-repeat: repeat-x;
-    background-size: 36px 20px;
+    background-size: 36px $bg-size-height;
     content: '';
   }
 }

--- a/components/common/Link.vue
+++ b/components/common/Link.vue
@@ -52,7 +52,7 @@ export default {
 
 <style lang="scss" scoped>
 .link {
-  @include wave($bottom: -22px);
+  @include wave($bottom: -22px, $height: 20px, $bg-size-height: 18px);
 
   display: inline-block;
   font-weight: var(--fw-semi-bold);
@@ -62,8 +62,8 @@ export default {
   &::after {
     cursor: pointer;
     transition: 0.5s ease, mask-position 0s 0.5s;
-    mask: linear-gradient(#fff 0 0) top / 100% calc(100% - 24px),
-      linear-gradient(#fff 0 0) var(--p, 0) 100% / var(--d, 0) 24px;
+    mask: linear-gradient(#fff 0 0) top / 100% calc(100% - 20px),
+      linear-gradient(#fff 0 0) var(--p, 0) 100% / var(--d, 0) 20px;
     mask-repeat: no-repeat;
   }
   &:hover {


### PR DESCRIPTION
## ✍️ Description
Updates wave `mixin` to be able to customize the wavy underline thickness. Make the link underline thinner using the new arguments in the `mixin`.

## ✅ QA

Before requesting a review, please make sure that:

- [x] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots
|Before|After|
|------|-----|
|<img width="825" alt="Screenshot 2021-05-26 at 12 36 44" src="https://user-images.githubusercontent.com/39853718/119646383-61dbf200-be1f-11eb-9a9a-a79a3d934e62.png">|<img width="827" alt="Screenshot 2021-05-26 at 12 36 57" src="https://user-images.githubusercontent.com/39853718/119646432-728c6800-be1f-11eb-8dd9-d2ac2994e356.png">|

## 🔗 Relevant URLs
- [Task](https://app.clickup.com/t/kd6tcr)