### PR TITLE
fix: hamburger menu

### DIFF
--- a/assets/scss/variables/_colors.scss
+++ b/assets/scss/variables/_colors.scss
@@ -41,8 +41,8 @@
   --bg-accent: var(--salmon);
   --bg-dimmed: var(--gray-400);
   --bg-close-icon: var(--gray-400);
-  --bg-hamburguer: var(--navy);
-  --bg-hamburguer--open: var(--white);
+  --bg-hamburger: var(--navy);
+  --bg-hamburger--open: var(--white);
   --bg-feedback--success: var(--pastel-green);
   --bg-feedback--warning: var(--anakiwa);
 

--- a/assets/scss/variables/_layout.scss
+++ b/assets/scss/variables/_layout.scss
@@ -4,7 +4,7 @@
   --z-index-content: 1;
   --z-index-topbar: 2;
   --z-index-navigation-mobile: 3;
-  --z-index-hamburguer: 4;
+  --z-index-hamburger: 4;
   --z-index-switch-off: 1;
   --z-index-switch-on: 2;
 }

--- a/components/Hamburger.vue
+++ b/components/Hamburger.vue
@@ -19,44 +19,46 @@ export default {
 
 <style lang="scss" scoped>
 .burger {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   span {
     position: relative;
     top: 0;
     display: block;
-    width: 28px;
-    height: 3px;
-    margin: 3px 0;
+    width: 33px;
+    height: 4px;
+    margin-bottom: 5px;
     background: var(--bg-hamburger);
     border-radius: 3px;
+    transform-origin: 4px 0;
     cursor: pointer;
-    transition: transform 0.2s linear, top 0.15s ease-in-out 0.3s,
-      color 0.25s ease 0.2s, width 0.25s ease 0.2s;
+    transition: transform 0.5s cubic-bezier(0.77, 0.2, 0.05, 1),
+      background 0.5s cubic-bezier(0.77, 0.2, 0.05, 1), opacity 0.55s ease;
+    &:first-child {
+      transform-origin: 0% 0%;
+    }
     &:nth-child(2) {
       width: 18px;
     }
     &:nth-child(3) {
-      width: 8px;
+      width: 10px;
+      transform-origin: 0% 100%;
     }
   }
   &--active {
+    display: block;
     span {
       background: var(--bg-hamburger--open);
-      &:nth-child(1) {
-        top: 6px;
-        transform: rotate(45deg);
-        transition: top 0.2s linear, transform 0.15s ease 0.3s,
-          color 0.25s ease 0.2s;
-      }
+      transform: rotate(45deg) translate(-2px, -1px);
+      opacity: 1;
       &:nth-child(2) {
-        width: 0;
-        transition: color 0.25s ease 0.2s;
+        transform: rotate(0deg) scale(0.2, 0.2);
+        opacity: 0;
       }
       &:nth-child(3) {
-        top: -6px;
-        width: 28px;
-        transform: rotate(-45deg);
-        transition: top 0.2s linear, transform 0.15s ease 0.3s,
-          color 0.25s ease 0.2s;
+        width: 33px;
+        transform: rotate(-45deg) translate(-2px, 0);
       }
     }
   }

--- a/components/Hamburger.vue
+++ b/components/Hamburger.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="burguer" :class="{ 'burguer--active': active }">
+  <div class="burger" :class="{ 'burger--active': active }">
     <span />
     <span />
     <span />
@@ -18,7 +18,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.burguer {
+.burger {
   span {
     position: relative;
     top: 0;
@@ -26,7 +26,7 @@ export default {
     width: 28px;
     height: 3px;
     margin: 3px 0;
-    background: var(--bg-hamburguer);
+    background: var(--bg-hamburger);
     border-radius: 3px;
     cursor: pointer;
     transition: transform 0.2s linear, top 0.15s ease-in-out 0.3s,
@@ -40,7 +40,7 @@ export default {
   }
   &--active {
     span {
-      background: var(--bg-hamburguer--open);
+      background: var(--bg-hamburger--open);
       &:nth-child(1) {
         top: 6px;
         transform: rotate(45deg);

--- a/components/Hamburguer.vue
+++ b/components/Hamburguer.vue
@@ -27,6 +27,7 @@ export default {
     height: 3px;
     margin: 3px 0;
     background: var(--bg-hamburguer);
+    border-radius: 3px;
     cursor: pointer;
     transition: transform 0.2s linear, top 0.15s ease-in-out 0.3s,
       color 0.25s ease 0.2s, width 0.25s ease 0.2s;

--- a/components/TopNav.vue
+++ b/components/TopNav.vue
@@ -26,11 +26,11 @@
           <span class="nav__home-date">2021</span>
         </div>
         <button
-          class="nav__hamburguer"
+          class="nav__hamburger"
           :aria-label="`${active ? 'Close' : 'Open'} navigation`"
           @click="toggleNav"
         >
-          <Hamburguer :active="active" />
+          <Hamburger :active="active" />
         </button>
         <div class="nav__container">
           <div class="nav__wrapper">
@@ -157,7 +157,7 @@ export default {
   padding: 36px 40px 18px;
   &__brand {
     position: relative;
-    z-index: var(--z-index-hamburguer);
+    z-index: var(--z-index-hamburger);
     display: flex;
     flex-wrap: nowrap;
     align-items: baseline;
@@ -300,9 +300,9 @@ export default {
     }
   }
 
-  &__hamburguer {
+  &__hamburger {
     position: relative;
-    z-index: var(--z-index-hamburguer);
+    z-index: var(--z-index-hamburger);
     display: none;
     width: 30px;
     height: 30px;

--- a/cypress/integration/layout.spec.js
+++ b/cypress/integration/layout.spec.js
@@ -12,7 +12,7 @@ describe('Default Layout', () => {
         cy.findByText('GMS').should('be.visible')
       })
     })
-    it('is displaying the hamburguer icon', () => {
+    it('is displaying the hamburger icon', () => {
       cy.get('[data-cy=navigation]').within(() => {
         cy.findByLabelText('Open navigation').should('be.visible')
       })


### PR DESCRIPTION
## ✍️ Description
Updates the hamburger menu icon to follow the design. I haven't used the SVGs in order to keep the smooth transition, although the transition has been updated a bit as well.

This PR also fixes a typo that was all over the app, so it changes all the `hamburguer` with `hamburger`.

## ✅ QA

Before requesting a review, please make sure that:

- [ ] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots
<img width="578" alt="Screenshot 2021-05-26 at 18 14 40" src="https://user-images.githubusercontent.com/39853718/119695212-40dec580-be4e-11eb-8b94-89f27fbd2d08.png">

## 🔗 Relevant URLs
- [Task](https://app.clickup.com/t/kd6rkw)