### PR TITLE
chore: add id video day 1 and publish hero live

### DIFF
--- a/components/home/Hero.vue
+++ b/components/home/Hero.vue
@@ -19,7 +19,7 @@ export default {
   },
   data() {
     return {
-      eventIsLive: false, // Change this attribute to toggle between the Hero and the Hero Live
+      eventIsLive: true, // Change this attribute to toggle between the Hero and the Hero Live
     }
   },
 }

--- a/components/home/HeroLive.vue
+++ b/components/home/HeroLive.vue
@@ -29,7 +29,7 @@ export default {
   },
   data() {
     return {
-      videoId: '5qap5aO4i9A', // TODO use the actual video id when publishing this component
+      videoId: 'xUms2fxciI0',
       gatherTown: null,
     }
   },

--- a/mixins/social-metadata.js
+++ b/mixins/social-metadata.js
@@ -8,7 +8,7 @@ const socialMetadata = {
       : 'A virtual event for the maintainers that make open source possible, hosted by GitHub.'
     const image = this.metadata?.image
       ? this.metadata.image
-      : 'https://globalmaintainersummit.github.com/social-card.jpg'
+      : 'https://globalmaintainersummit.github.com/social-card-live.jpg'
     const meta = [
       {
         hid: 'description',


### PR DESCRIPTION
## ✍️ Description
- Add the actual YouTube video id for the first day.
- Publish Hero live and hide Hero normal.
- Use the social card for the live event.

## ✅ QA

Before requesting a review, please make sure that:

- [x] Preview is working on Netlify, Heroku or similar.
- [x] Manually check that it's working.
- [ ] Add documentation and tests if needed.

## 📸 Screenshots
![Screenshot 2021-06-08 at 08 40 48](https://user-images.githubusercontent.com/39853718/121135869-3b618200-c835-11eb-88d3-865f0be650aa.png)

## 🔗 Relevant URLs
- [Task](https://app.clickup.com/t/m3d6we)